### PR TITLE
Updated auth0 version

### DIFF
--- a/mystic_tuner_frontend/package-lock.json
+++ b/mystic_tuner_frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mystic_tuner_frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@auth0/nextjs-auth0": "^4.0.3",
+        "@auth0/nextjs-auth0": "^4.0.2",
         "@heroui/accordion": "^2.2.12",
         "@heroui/autocomplete": "^2.3.16",
         "@heroui/avatar": "^2.2.11",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@auth0/nextjs-auth0": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-4.0.3.tgz",
-      "integrity": "sha512-I5/LOi11j7urLvjzkik+6W4izn/Pi1gVnOC3DWKUkL44u6vR1pzlavJrGBwQ5xsvh1RcGa2qWiJpDtN5wy/iOQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-4.0.2.tgz",
+      "integrity": "sha512-vi2hE3OaFz2KzR/VFwC8VVzbfqmyoTMYpjM9gjGg2jFKGzHnE6T6+7T0ecv3XBpF5NeO9CE36V3d5Xgn2HedhQ==",
       "license": "MIT",
       "dependencies": {
         "@edge-runtime/cookies": "^5.0.1",
@@ -7240,9 +7240,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.2.0.tgz",
-      "integrity": "sha512-2sYwQXuuzGKOHpnM7QL9BssDrly5gKCgJKTyrhmFIHzJRj0fFsr6GVJEdesmrX6NpMg2u63V4hJwRsZE6PUSSA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.3.1.tgz",
+      "integrity": "sha512-ZwX7UqYrP3Lr+Glhca3a1/nF2jqf7VVyJfhGuW5JtrfDUxt0u+IoBPzFjZ2dd7PJGkdM6CFPVVYzuDYKHv101A==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8553,9 +8553,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.2.tgz",
-      "integrity": "sha512-RosxFpiabojs75IwQ316DGoDRmOqtiAj0tg8wCcbEu4CiLZBs/a9QNtHV7TUfDXmmlgqij/NqzKq/eLelyv9xA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",

--- a/mystic_tuner_frontend/package.json
+++ b/mystic_tuner_frontend/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^4.0.3",
+    "@auth0/nextjs-auth0": "^4.0.2",
     "@heroui/accordion": "^2.2.12",
     "@heroui/autocomplete": "^2.3.16",
     "@heroui/avatar": "^2.2.11",


### PR DESCRIPTION
Resolved issue with auth0 that was causing 'version' errors in heroku deployment. Required to rollback auth0 installation to 4.0.2 (was 4.0.3). Tested by running npm run build and npm run start (both worked)